### PR TITLE
updated line numbers and prism working.

### DIFF
--- a/src/LaylasLittleCompanion.Server/Pages/Blog.razor
+++ b/src/LaylasLittleCompanion.Server/Pages/Blog.razor
@@ -33,7 +33,7 @@
 					<div class="">
 						<img src=""
 							 class="" />
-						<div>
+						<div class="line-numbers">
 							@ConvertToMarkUp(item.body)
 						</div>
 					</div>
@@ -69,7 +69,7 @@
 	protected override async Task OnAfterRenderAsync(bool firstRender)
 	{
 		//todo: this isn't working as expected - lines are not highlighting
-		await _jsRuntime.InvokeVoidAsync("Prism.highlightAll");
+		await _jsRuntime.InvokeVoidAsync("highlightCode");
 	}
 
 	private string BuildHtmlFromMarkdown(string value) => Markdig.Markdown.ToHtml(

--- a/src/LaylasLittleCompanion.Server/Pages/_Host.cshtml
+++ b/src/LaylasLittleCompanion.Server/Pages/_Host.cshtml
@@ -33,5 +33,6 @@
 	<script src="_framework/blazor.server.js"></script>
 	<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta3/dist/js/bootstrap.bundle.min.js"></script>
 	<script src="js/prism.js"></script>
+  <script src="js/functions.js"></script>
 	</body>
 </html>

--- a/src/LaylasLittleCompanion.Server/wwwroot/js/functions.js
+++ b/src/LaylasLittleCompanion.Server/wwwroot/js/functions.js
@@ -1,0 +1,3 @@
+
+// a place for furture js IJSRuntime  items
+window.highlightCode = () => window.Prism.highlightAll();


### PR DESCRIPTION
the prism addon in nuget will wipe html attributes so you have to add "line numbers" class (anywhere) really it can't be passed into the plugin. it will target the pre/code attributes on page.